### PR TITLE
Fix build of several cores

### DIFF
--- a/classes/libretro.bbclass
+++ b/classes/libretro.bbclass
@@ -114,14 +114,14 @@ DEPENDS += " \
 "
 
 do_compile() {
-  if [[ ! -z "${LIBRETRO_MAKEFILE_PREFIX}" ]]; then
+  if [ ! -z "${LIBRETRO_MAKEFILE_PREFIX}" ]; then
     echo "prefix changed: ${LIBRETRO_MAKEFILE_PREFIX}"
     cd ${LIBRETRO_MAKEFILE_PREFIX}
   fi
 
   MAKEFILE_PATH="Makefile";
-  [[ -f "Makefile.libretro" ]] && MAKEFILE_PATH="Makefile.libretro"
-  [[ -f "${LIBRETRO_MAKEFILE_FILENAME_OVERRIDE}" ]] && MAKEFILE_PATH="${LIBRETRO_MAKEFILE_FILENAME_OVERRIDE}"
+  [ -f "Makefile.libretro" ] && MAKEFILE_PATH="Makefile.libretro"
+  [ -f "${LIBRETRO_MAKEFILE_FILENAME_OVERRIDE}" ] && MAKEFILE_PATH="${LIBRETRO_MAKEFILE_FILENAME_OVERRIDE}"
 
   oe_runmake -f "${MAKEFILE_PATH}" ${LIBRETRO_FINAL_MAKEFLAGS} \
     ARCH=${LIBRETRO_CPU_ARCH} \


### PR DESCRIPTION
Fix Makefile.libretro getting ignored as [[ ]] is unknown to command line interpreter. Changed to more portable syntax []. Prevents several cores (e.g. Genesis-Plus-GX) from failing to build on Ubuntu 20.04.
