### PR TITLE
Fix Picodrive compile-time segfault. Call Make the way they do in Lakka.

### DIFF
--- a/recipes-libretro/picodrive-libretro/picodrive-libretro_git.bb
+++ b/recipes-libretro/picodrive-libretro/picodrive-libretro_git.bb
@@ -6,3 +6,21 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4613340462793d879916d43aa44d4236"
 inherit libretro
 
 LIBRETRO_GIT_REPO = "github.com/libretro/picodrive.git"
+
+do_compile() {
+  if [ ! -z "${LIBRETRO_MAKEFILE_PREFIX}" ]; then
+    echo "prefix changed: ${LIBRETRO_MAKEFILE_PREFIX}"
+    cd ${LIBRETRO_MAKEFILE_PREFIX}
+  fi
+  
+  if [ "${TUNE_ARCH}" = "arm" ]; then
+    oe_runmake -f Makefile.libretro platform=armv
+  elif [ "${TUNE_ARCH}" = "aarch64" ]; then
+    oe_runmake -f Makefile.libretro platform=aarch64
+  else   
+    oe_runmake -f Makefile.libretro ${LIBRETRO_FINAL_MAKEFLAGS} \
+    ARCH=${LIBRETRO_CPU_ARCH} \
+    ARM="${IS_ARM_ARCH}" \
+    CPU_ARCH=${TUNE_ARCH}
+  fi
+}


### PR DESCRIPTION
Host: Ubuntu 20.4 64.bit
Target: rpi3 32-bit

Fixes compile time segfault. First solution to pre-build ASM 68k Core for ARM seemed to work but provided a segfault on target. 

Similar Issue:
https://github.com/libretro/libretro-super/issues/1116

Now I call Make the way Lakka does and it's working perfectly. 
WARNING: Untested for ARM 64 bit / intel