### PR TITLE
resize-helper: add DISTRO_FEATURE to resize root partition on first boot

### DIFF
--- a/classes/retro-core-image.bbclass
+++ b/classes/retro-core-image.bbclass
@@ -11,7 +11,7 @@ IMAGE_INSTALL += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'retroarch-automount', 'udev-extraconf', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'retroarch-autostart systemd', 'retroarch-service', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'retroarch-firmware', 'firmware-libretro', '', d)} \
-    ${@bb.utils.filter('DISTRO_FEATURES', 'kodi rauc polkit', d)} \
+    ${@bb.utils.filter('DISTRO_FEATURES', 'kodi rauc resize-helper polkit', d)} \
     kernel-modules \
     packagegroup-libretro-cores \
     retro-user \

--- a/recipes-extended/resize-helper/files/resize-helper
+++ b/recipes-extended/resize-helper/files/resize-helper
@@ -1,0 +1,61 @@
+#!/bin/sh
+# Copyright (c) Fathi Boudra <fathi.boudra@linaro.org>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+
+# we must be root
+[ $(whoami) = "root" ] || { echo "E: You must be root" && exit 1; }
+
+# we must have few tools
+SGDISK=$(which sgdisk) || { echo "E: You must have sgdisk" && exit 1; }
+PARTED=$(which parted) || { echo "E: You must have parted" && exit 1; }
+PARTPROBE=$(which partprobe) || { echo "E: You must have partprobe" && exit 1; }
+RESIZE2FS=$(which resize2fs) || { echo "E: You must have resize2fs" && exit 1; }
+BLKID=$(which blkid) || { echo "E: You must have blkid" && exit 1; }
+
+# find root device
+ROOT_DEVICE=$(findmnt / -o source -n)
+# prune root device (for example UUID)
+ROOT_DEVICE=$(realpath ${ROOT_DEVICE})
+# get the partition number and type
+ROOT_PART_NAME=$(echo "$ROOT_DEVICE" | cut -d "/" -f 3)
+DEVICE_NAME=$(echo /sys/block/*/"${ROOT_PART_NAME}" | cut -d "/" -f 4)
+DEVICE="/dev/${DEVICE_NAME}"
+PART_ENTRY_NUMBER=$(cat "/sys/block/${DEVICE_NAME}/${ROOT_PART_NAME}/partition")
+PART_TABLE_TYPE=$(${BLKID} -o value -s PTTYPE "${DEVICE}")
+DEVICE_SIZE=$(cat "/sys/block/${DEVICE_NAME}/size")
+END_SIZE=$((DEVICE_SIZE - 1))
+
+# in case the root device is not on a partitioned media
+if [ "x$PART_ENTRY_NUMBER" = "x" ]; then
+	${RESIZE2FS} "${ROOT_DEVICE}"
+	exit 0
+fi
+
+if [ "$PART_TABLE_TYPE" = "gpt" ]; then
+	${SGDISK} -e ${DEVICE}
+	${PARTPROBE}
+fi
+${PARTED} ${DEVICE} resizepart ${PART_ENTRY_NUMBER} 100%
+${PARTPROBE}
+${RESIZE2FS} "${ROOT_DEVICE}"

--- a/recipes-extended/resize-helper/files/resize-helper.service
+++ b/recipes-extended/resize-helper/files/resize-helper.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Resize root filesystem to fit available disk space
+Wants=systemd-udevd.service systemd-udev-trigger.service
+After=systemd-remount-fs.service systemd-udevd.service
+
+[Service]
+Type=oneshot
+ExecStartPre=-/bin/udevadm settle
+ExecStart=-/usr/sbin/resize-helper
+ExecStartPost=/bin/systemctl disable resize-helper.service
+
+[Install]
+WantedBy=basic.target

--- a/recipes-extended/resize-helper/resize-helper.bb
+++ b/recipes-extended/resize-helper/resize-helper.bb
@@ -1,0 +1,26 @@
+SUMMARY = "Resize root filesystem to fit available disk space"
+DESCRIPTION = "Resize root filesystem to fit available disk space"
+SECTION = "admin"
+
+LICENSE = "BSD-2-Clause"
+LIC_FILES_CHKSUM = "file://${WORKDIR}/resize-helper;beginline=1;endline=24;md5=c86f62e2fddb47a7dc1f398b2aff4912"
+
+SRC_URI = " \
+	file://resize-helper.service \
+	file://resize-helper \
+"
+
+inherit features_check systemd
+
+CONFLICT_DISTRO_FEATURES = "rauc"
+
+RDEPENDS_${PN} += "e2fsprogs-resize2fs gptfdisk parted util-linux udev"
+
+do_install() {
+	install -d ${D}${systemd_system_unitdir}
+	install -m 0644 ${WORKDIR}/resize-helper.service ${D}${systemd_system_unitdir}
+	install -d ${D}${sbindir}
+	install -m 0755 ${WORKDIR}/resize-helper ${D}${sbindir}
+}
+
+SYSTEMD_SERVICE_${PN} = "resize-helper.service"


### PR DESCRIPTION
resize root partition to make the complete disk space available

Signed-off-by: Markus Volk <f_l_k@t-online.de>

I was missing a possibility to automatically resize the rootfs to make use of the complete install medium and thus did import this from meta-radxa to my local meta-rockchip-extras layer. But since it looks like this will work for all platforms maybe it would be a good idea to make this available as a DISTRO_FEATURE ?