### PR TITLE
retro-raspberrypi.inc: lower cma allocation

### DIFF
--- a/conf/distro/include/retro-raspberrypi.inc
+++ b/conf/distro/include/retro-raspberrypi.inc
@@ -10,8 +10,8 @@ PACKAGECONFIG_append_pn-mesa_rpi = " v3d vc4"
 RPI_KERNEL_DEVICETREE_OVERLAYS_append_rpi_full-kms = " overlays/cma.dtbo overlays/vc4-kms-v3d-pi4.dtbo overlays/rpivid-v4l2.dtbo"
 
 VC4_DTBO_VARIANT = "vc4-kms-v3d"
-VC4_DTBO_VARIANT_raspberrypi4 = "vc4-kms-v3d-pi4,cma-512"
-VC4_DTBO_VARIANT_raspberrypi4-64 = "vc4-kms-v3d-pi4,cma-512"
+VC4_DTBO_VARIANT_raspberrypi4 = "vc4-kms-v3d-pi4,cma-320"
+VC4_DTBO_VARIANT_raspberrypi4-64 = "vc4-kms-v3d-pi4,cma-320"
 
 VC4DTBO_rpi_full-kms = "${VC4_DTBO_VARIANT}"
 


### PR DESCRIPTION
with recent code the kernel crashes at boot if 512MB cma size is set