### PR TITLE
retroarch-database: fix packaging

### DIFF
--- a/recipes-retroarch/retroarch-database/retroarch-database.bb
+++ b/recipes-retroarch/retroarch-database/retroarch-database.bb
@@ -25,7 +25,8 @@ FILES:${PN}-cheats = "${RETROARCH_DATABASE_CHEATS_DIR}"
 FILES:${PN}-cursors = "${RETROARCH_DATABASE_CURSORS_DIR}"
 FILES:${PN}-titles = "${RETROARCH_DATABASE_TITLES_DIR}"
 
-FILES:${PN} += "${RETROARCH_DATABASE_DIR}"
+FILES:${PN} = ""
+ALLOW_EMPTY:${PN} = "1"
 
 do_patch() {
 # FIXME: files with character [ or ] failing at rpm package stage


### PR DESCRIPTION
Signed-off-by: Markus Volk <f_l_k@t-online.de>

i need this change to be able to install either one of
retroarch-database-cheats
retroarch-database-cursors
retroarch-datbase-titles
