### PR TITLE
dolphin-libretro: fix buid for aarch64

### DIFF
--- a/recipes-libretro/dolphin-libretro/dolphin-libretro/0001-JitArm64-Fix-improper-uses-of-offsetof.patch
+++ b/recipes-libretro/dolphin-libretro/dolphin-libretro/0001-JitArm64-Fix-improper-uses-of-offsetof.patch
@@ -1,0 +1,335 @@
+From 7094e1c5b97af456d0f25875795515bf59069170 Mon Sep 17 00:00:00 2001
+From: Markus Volk <f_l_k@t-online.de>
+Date: Tue, 11 Jan 2022 12:23:46 +0100
+Subject: [PATCH] JitArm64: backport fix
+
+Upstream-Status: Backport
+
+Compile fix for aarch64.
+
+Signed-off-by: Markus Volk <f_l_k@t-online.de>
+---
+ Source/Core/Core/PowerPC/JitArm64/Jit.cpp     |  2 +-
+ .../Core/PowerPC/JitArm64/JitArm64_Branch.cpp | 24 +++++++++----------
+ .../JitArm64/JitArm64_LoadStorePaired.cpp     |  4 ++--
+ .../PowerPC/JitArm64/JitArm64_RegCache.cpp    | 20 ++++++++--------
+ .../Core/PowerPC/JitArm64/JitArm64_RegCache.h | 19 ++++++++++++---
+ .../JitArm64/JitArm64_SystemRegisters.cpp     | 14 +++++------
+ 6 files changed, 48 insertions(+), 35 deletions(-)
+
+diff --git a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+index 3a48ae7df4..3dc8ad4686 100644
+--- a/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
++++ b/Source/Core/Core/PowerPC/JitArm64/Jit.cpp
+@@ -637,7 +637,7 @@ void JitArm64::DoJit(u32 em_address, JitBlock* b, u32 nextPC)
+     int gqr = *code_block.m_gqr_used.begin();
+     if (!code_block.m_gqr_modified[gqr] && !GQR(gqr))
+     {
+-      LDR(INDEX_UNSIGNED, W0, PPC_REG, PPCSTATE_OFF(spr[SPR_GQR0]) + gqr * 4);
++      LDR(INDEX_UNSIGNED, W0, PPC_REG, PPCSTATE_OFF_SPR(SPR_GQR0 + gqr));
+       FixupBranch no_fail = CBZ(W0);
+       FixupBranch fail = B();
+       SwitchToFarCode();
+diff --git a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
+index a4150d86d7..132b5ba9b3 100644
+--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
++++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_Branch.cpp
+@@ -57,14 +57,14 @@ void JitArm64::rfi(UGeckoInstruction inst)
+ 
+   ANDI2R(WC, WC, (~mask) & clearMSR13, WA);  // rD = Masked MSR
+ 
+-  LDR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(spr[SPR_SRR1]));  // rB contains SRR1 here
++  LDR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF_SPR(SPR_SRR1));  // rB contains SRR1 here
+ 
+   ANDI2R(WA, WA, mask & clearMSR13, WB);  // rB contains masked SRR1 here
+   ORR(WA, WA, WC);                        // rB = Masked MSR OR masked SRR1
+ 
+   STR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(msr));  // STR rB in to rA
+ 
+-  LDR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(spr[SPR_SRR0]));
++  LDR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF_SPR(SPR_SRR0));
+   gpr.Unlock(WB, WC);
+ 
+   WriteExceptionExit(WA);
+@@ -80,7 +80,7 @@ void JitArm64::bx(UGeckoInstruction inst)
+   {
+     ARM64Reg WA = gpr.GetReg();
+     MOVI2R(WA, js.compilerPC + 4);
+-    STR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(spr[SPR_LR]));
++    STR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF_SPR(SPR_LR));
+     gpr.Unlock(WA);
+   }
+ 
+@@ -125,9 +125,9 @@ void JitArm64::bcx(UGeckoInstruction inst)
+   FixupBranch pCTRDontBranch;
+   if ((inst.BO & BO_DONT_DECREMENT_FLAG) == 0)  // Decrement and test CTR
+   {
+-    LDR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(spr[SPR_CTR]));
++    LDR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF_SPR(SPR_CTR));
+     SUBS(WA, WA, 1);
+-    STR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(spr[SPR_CTR]));
++    STR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF_SPR(SPR_CTR));
+ 
+     if (inst.BO & BO_BRANCH_IF_CTR_0)
+       pCTRDontBranch = B(CC_NEQ);
+@@ -150,7 +150,7 @@ void JitArm64::bcx(UGeckoInstruction inst)
+   if (inst.LK)
+   {
+     MOVI2R(WA, js.compilerPC + 4);
+-    STR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(spr[SPR_LR]));
++    STR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF_SPR(SPR_LR));
+   }
+   gpr.Unlock(WA);
+ 
+@@ -213,13 +213,13 @@ void JitArm64::bcctrx(UGeckoInstruction inst)
+   {
+     ARM64Reg WB = gpr.GetReg();
+     MOVI2R(WB, js.compilerPC + 4);
+-    STR(INDEX_UNSIGNED, WB, PPC_REG, PPCSTATE_OFF(spr[SPR_LR]));
++    STR(INDEX_UNSIGNED, WB, PPC_REG, PPCSTATE_OFF_SPR(SPR_LR));
+     gpr.Unlock(WB);
+   }
+ 
+   ARM64Reg WA = gpr.GetReg();
+ 
+-  LDR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(spr[SPR_CTR]));
++  LDR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF_SPR(SPR_CTR));
+   AND(WA, WA, 30, 29);  // Wipe the bottom 2 bits.
+ 
+   WriteExit(WA, inst.LK_3, js.compilerPC + 4);
+@@ -241,9 +241,9 @@ void JitArm64::bclrx(UGeckoInstruction inst)
+   FixupBranch pCTRDontBranch;
+   if ((inst.BO & BO_DONT_DECREMENT_FLAG) == 0)  // Decrement and test CTR
+   {
+-    LDR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(spr[SPR_CTR]));
++    LDR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF_SPR(SPR_CTR));
+     SUBS(WA, WA, 1);
+-    STR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(spr[SPR_CTR]));
++    STR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF_SPR(SPR_CTR));
+ 
+     if (inst.BO & BO_BRANCH_IF_CTR_0)
+       pCTRDontBranch = B(CC_NEQ);
+@@ -265,13 +265,13 @@ void JitArm64::bclrx(UGeckoInstruction inst)
+     SetJumpTarget(far_addr);
+   }
+ 
+-  LDR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF(spr[SPR_LR]));
++  LDR(INDEX_UNSIGNED, WA, PPC_REG, PPCSTATE_OFF_SPR(SPR_LR));
+   AND(WA, WA, 30, 29);  // Wipe the bottom 2 bits.
+ 
+   if (inst.LK)
+   {
+     MOVI2R(WB, js.compilerPC + 4);
+-    STR(INDEX_UNSIGNED, WB, PPC_REG, PPCSTATE_OFF(spr[SPR_LR]));
++    STR(INDEX_UNSIGNED, WB, PPC_REG, PPCSTATE_OFF_SPR(SPR_LR));
+     gpr.Unlock(WB);
+   }
+ 
+diff --git a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
+index f6a63ee2e6..9a41d91303 100644
+--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
++++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_LoadStorePaired.cpp
+@@ -77,7 +77,7 @@ void JitArm64::psq_l(UGeckoInstruction inst)
+   }
+   else
+   {
+-    LDR(INDEX_UNSIGNED, scale_reg, PPC_REG, PPCSTATE_OFF(spr[SPR_GQR0 + inst.I]));
++    LDR(INDEX_UNSIGNED, scale_reg, PPC_REG, PPCSTATE_OFF_SPR(SPR_GQR0 + inst.I));
+     UBFM(type_reg, scale_reg, 16, 18);   // Type
+     UBFM(scale_reg, scale_reg, 24, 29);  // Scale
+ 
+@@ -179,7 +179,7 @@ void JitArm64::psq_st(UGeckoInstruction inst)
+         m_float_emit.FCVTN(32, D0, VS);
+     }
+ 
+-    LDR(INDEX_UNSIGNED, scale_reg, PPC_REG, PPCSTATE_OFF(spr[SPR_GQR0 + inst.I]));
++    LDR(INDEX_UNSIGNED, scale_reg, PPC_REG, PPCSTATE_OFF_SPR(SPR_GQR0 + inst.I));
+     UBFM(type_reg, scale_reg, 0, 2);    // Type
+     UBFM(scale_reg, scale_reg, 8, 13);  // Scale
+ 
+diff --git a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
+index dc775ef607..4b759f683a 100644
+--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
++++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.cpp
+@@ -133,13 +133,13 @@ const OpArg& Arm64GPRCache::GetGuestGPROpArg(size_t preg) const
+ Arm64GPRCache::GuestRegInfo Arm64GPRCache::GetGuestGPR(size_t preg)
+ {
+   ASSERT(preg < GUEST_GPR_COUNT);
+-  return {32, PPCSTATE_OFF(gpr[preg]), m_guest_registers[GUEST_GPR_OFFSET + preg]};
++  return {32, PPCSTATE_OFF_GPR(preg), m_guest_registers[GUEST_GPR_OFFSET + preg]};
+ }
+ 
+ Arm64GPRCache::GuestRegInfo Arm64GPRCache::GetGuestCR(size_t preg)
+ {
+   ASSERT(preg < GUEST_CR_COUNT);
+-  return {64, PPCSTATE_OFF(cr.fields[preg]), m_guest_registers[GUEST_CR_OFFSET + preg]};
++  return {64, PPCSTATE_OFF_CR(preg), m_guest_registers[GUEST_CR_OFFSET + preg]};
+ }
+ 
+ Arm64GPRCache::GuestRegInfo Arm64GPRCache::GetGuestByIndex(size_t index)
+@@ -451,7 +451,7 @@ ARM64Reg Arm64FPRCache::R(size_t preg, RegType type)
+       // Load the high 64bits from the file and insert them in to the high 64bits of the host
+       // register
+       ARM64Reg tmp_reg = GetReg();
+-      m_float_emit->LDR(64, INDEX_UNSIGNED, tmp_reg, PPC_REG, u32(PPCSTATE_OFF(ps[preg].ps1)));
++      m_float_emit->LDR(64, INDEX_UNSIGNED, tmp_reg, PPC_REG, u32(PPCSTATE_OFF_PS1(preg)));
+       m_float_emit->INS(64, host_reg, 1, tmp_reg, 0);
+       UnlockRegister(tmp_reg);
+ 
+@@ -505,7 +505,7 @@ ARM64Reg Arm64FPRCache::R(size_t preg, RegType type)
+     }
+     reg.SetDirty(false);
+     m_float_emit->LDR(load_size, INDEX_UNSIGNED, host_reg, PPC_REG,
+-                      u32(PPCSTATE_OFF(ps[preg].ps0)));
++                      u32(PPCSTATE_OFF_PS0(preg)));
+     return host_reg;
+   }
+   default:
+@@ -553,7 +553,7 @@ ARM64Reg Arm64FPRCache::RW(size_t preg, RegType type)
+       // We are doing a full 128bit store because it takes 2 cycles on a Cortex-A57 to do a 128bit
+       // store.
+       // It would take longer to do an insert to a temporary and a 64bit store than to just do this.
+-      m_float_emit->STR(128, INDEX_UNSIGNED, flush_reg, PPC_REG, u32(PPCSTATE_OFF(ps[preg].ps0)));
++      m_float_emit->STR(128, INDEX_UNSIGNED, flush_reg, PPC_REG, u32(PPCSTATE_OFF_PS0(preg)));
+       break;
+     case REG_DUP_SINGLE:
+       flush_reg = GetReg();
+@@ -561,7 +561,7 @@ ARM64Reg Arm64FPRCache::RW(size_t preg, RegType type)
+       [[fallthrough]];
+     case REG_DUP:
+       // Store PSR1 (which is equal to PSR0) in memory.
+-      m_float_emit->STR(64, INDEX_UNSIGNED, flush_reg, PPC_REG, u32(PPCSTATE_OFF(ps[preg].ps1)));
++      m_float_emit->STR(64, INDEX_UNSIGNED, flush_reg, PPC_REG, u32(PPCSTATE_OFF_PS1(preg)));
+       break;
+     default:
+       // All other types doesn't store anything in PSR1.
+@@ -688,7 +688,7 @@ void Arm64FPRCache::FlushRegister(size_t preg, bool maintain_state)
+     if (dirty)
+     {
+       m_float_emit->STR(store_size, INDEX_UNSIGNED, host_reg, PPC_REG,
+-                        u32(PPCSTATE_OFF(ps[preg].ps0)));
++                        u32(PPCSTATE_OFF_PS0(preg)));
+     }
+ 
+     if (!maintain_state)
+@@ -704,9 +704,9 @@ void Arm64FPRCache::FlushRegister(size_t preg, bool maintain_state)
+       // If the paired registers were at the start of ppcState we could do an STP here.
+       // Too bad moving them would break savestate compatibility between x86_64 and AArch64
+       // m_float_emit->STP(64, INDEX_SIGNED, host_reg, host_reg, PPC_REG,
+-      // PPCSTATE_OFF(ps[preg].ps0));
+-      m_float_emit->STR(64, INDEX_UNSIGNED, host_reg, PPC_REG, u32(PPCSTATE_OFF(ps[preg].ps0)));
+-      m_float_emit->STR(64, INDEX_UNSIGNED, host_reg, PPC_REG, u32(PPCSTATE_OFF(ps[preg].ps1)));
++      // PPCSTATE_OFF_PS0));
++      m_float_emit->STR(64, INDEX_UNSIGNED, host_reg, PPC_REG, u32(PPCSTATE_OFF_PS0(preg)));
++      m_float_emit->STR(64, INDEX_UNSIGNED, host_reg, PPC_REG, u32(PPCSTATE_OFF_PS1(preg)));
+     }
+ 
+     if (!maintain_state)
+diff --git a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
+index 9860e4843e..42d4bb9d7d 100644
+--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
++++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_RegCache.h
+@@ -6,6 +6,7 @@
+ 
+ #include <cstddef>
+ #include <memory>
++#include <type_traits>
+ #include <vector>
+ 
+ #include "Common/Arm64Emitter.h"
+@@ -22,10 +23,22 @@ static const Arm64Gen::ARM64Reg DISPATCHER_PC =
+ 
+ #define PPCSTATE_OFF(elem) (offsetof(PowerPC::PowerPCState, elem))
+ 
++#define PPCSTATE_OFF_ARRAY(elem, i)                                                                \
++  (offsetof(PowerPC::PowerPCState, elem[0]) + sizeof(PowerPC::PowerPCState::elem[0]) * (i))
++
++#define PPCSTATE_OFF_GPR(i) PPCSTATE_OFF_ARRAY(gpr, i)
++#define PPCSTATE_OFF_CR(i) PPCSTATE_OFF_ARRAY(cr.fields, i)
++#define PPCSTATE_OFF_SR(i) PPCSTATE_OFF_ARRAY(sr, i)
++#define PPCSTATE_OFF_SPR(i) PPCSTATE_OFF_ARRAY(spr, i)
++
++static_assert(std::is_same_v<decltype(PowerPC::PowerPCState::ps[0]), PowerPC::PairedSingle&>);
++#define PPCSTATE_OFF_PS0(i) (PPCSTATE_OFF_ARRAY(ps, i) + offsetof(PowerPC::PairedSingle, ps0))
++#define PPCSTATE_OFF_PS1(i) (PPCSTATE_OFF_ARRAY(ps, i) + offsetof(PowerPC::PairedSingle, ps1))
++
++
+ // Some asserts to make sure we will be able to load everything
+-static_assert(PPCSTATE_OFF(spr[1023]) <= 16380, "LDR(32bit) can't reach the last SPR");
+-static_assert((PPCSTATE_OFF(ps[0].ps0) % 8) == 0,
+-              "LDR(64bit VFP) requires FPRs to be 8 byte aligned");
++static_assert(PPCSTATE_OFF_SPR(1023) <= 16380, "LDR(32bit) can't reach the last SPR");
++static_assert((PPCSTATE_OFF_PS0(0) % 8) == 0, "LDR(64bit VFP) requires FPRs to be 8 byte aligned");
+ static_assert(PPCSTATE_OFF(xer_ca) < 4096, "STRB can't store xer_ca!");
+ static_assert(PPCSTATE_OFF(xer_so_ov) < 4096, "STRB can't store xer_so_ov!");
+ 
+diff --git a/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp b/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
+index d5889fd62c..bcc1b69f67 100644
+--- a/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
++++ b/Source/Core/Core/PowerPC/JitArm64/JitArm64_SystemRegisters.cpp
+@@ -111,7 +111,7 @@ void JitArm64::mfsr(UGeckoInstruction inst)
+   JITDISABLE(bJITSystemRegistersOff);
+ 
+   gpr.BindToRegister(inst.RD, false);
+-  LDR(INDEX_UNSIGNED, gpr.R(inst.RD), PPC_REG, PPCSTATE_OFF(sr[inst.SR]));
++  LDR(INDEX_UNSIGNED, gpr.R(inst.RD), PPC_REG, PPCSTATE_OFF_SR(inst.SR));
+ }
+ 
+ void JitArm64::mtsr(UGeckoInstruction inst)
+@@ -120,7 +120,7 @@ void JitArm64::mtsr(UGeckoInstruction inst)
+   JITDISABLE(bJITSystemRegistersOff);
+ 
+   gpr.BindToRegister(inst.RS, true);
+-  STR(INDEX_UNSIGNED, gpr.R(inst.RS), PPC_REG, PPCSTATE_OFF(sr[inst.SR]));
++  STR(INDEX_UNSIGNED, gpr.R(inst.RS), PPC_REG, PPCSTATE_OFF_SR(inst.SR));
+ }
+ 
+ void JitArm64::mfsrin(UGeckoInstruction inst)
+@@ -137,7 +137,7 @@ void JitArm64::mfsrin(UGeckoInstruction inst)
+ 
+   UBFM(index, RB, 28, 31);
+   ADD(index64, PPC_REG, index64, ArithOption(index64, ST_LSL, 2));
+-  LDR(INDEX_UNSIGNED, gpr.R(d), index64, PPCSTATE_OFF(sr[0]));
++  LDR(INDEX_UNSIGNED, gpr.R(d), index64, PPCSTATE_OFF_SR(0));
+ 
+   gpr.Unlock(index);
+ }
+@@ -156,7 +156,7 @@ void JitArm64::mtsrin(UGeckoInstruction inst)
+ 
+   UBFM(index, RB, 28, 31);
+   ADD(index64, PPC_REG, index64, ArithOption(index64, ST_LSL, 2));
+-  STR(INDEX_UNSIGNED, gpr.R(d), index64, PPCSTATE_OFF(sr[0]));
++  STR(INDEX_UNSIGNED, gpr.R(d), index64, PPCSTATE_OFF_SR(0));
+ 
+   gpr.Unlock(index);
+ }
+@@ -283,7 +283,7 @@ void JitArm64::mfspr(UGeckoInstruction inst)
+     UMULH(Xresult, Xresult, XB);
+ 
+     ADD(Xresult, XA, Xresult, ArithOption(Xresult, ST_LSR, 3));
+-    STR(INDEX_UNSIGNED, Xresult, PPC_REG, PPCSTATE_OFF(spr[SPR_TL]));
++    STR(INDEX_UNSIGNED, Xresult, PPC_REG, PPCSTATE_OFF_SPR(SPR_TL));
+ 
+     if (CanMergeNextInstructions(1))
+     {
+@@ -344,7 +344,7 @@ void JitArm64::mfspr(UGeckoInstruction inst)
+   default:
+     gpr.BindToRegister(d, false);
+     ARM64Reg RD = gpr.R(d);
+-    LDR(INDEX_UNSIGNED, RD, PPC_REG, PPCSTATE_OFF(spr) + iIndex * 4);
++    LDR(INDEX_UNSIGNED, RD, PPC_REG, PPCSTATE_OFF_SPR(iIndex));
+     break;
+   }
+ }
+@@ -408,7 +408,7 @@ void JitArm64::mtspr(UGeckoInstruction inst)
+ 
+   // OK, this is easy.
+   ARM64Reg RD = gpr.R(inst.RD);
+-  STR(INDEX_UNSIGNED, RD, PPC_REG, PPCSTATE_OFF(spr) + iIndex * 4);
++  STR(INDEX_UNSIGNED, RD, PPC_REG, PPCSTATE_OFF_SPR(iIndex));
+ }
+ 
+ void JitArm64::crXXX(UGeckoInstruction inst)
+-- 
+2.25.1
+

--- a/recipes-libretro/dolphin-libretro/dolphin-libretro_git.bb
+++ b/recipes-libretro/dolphin-libretro/dolphin-libretro_git.bb
@@ -10,41 +10,40 @@ require files/dolphin-32bit-configuration.inc
 
 LIBRETRO_GIT_REPO = "github.com/libretro/dolphin.git"
 
+SRC_URI:append = " file://0001-JitArm64-Fix-improper-uses-of-offsetof.patch"
+
 DEPENDS = " \
   ${@bb.utils.contains('DISTRO_FEATURES', 'retroarch-opengl', 'virtual/libgl ', '', d)} \
-  spirv-tools \
+  curl \
+  fmt \
   libusb \
+  pugixml \
+  xz \
+  zlib \
 "
 
 PACKAGECONFIG ?=  " \
   ${@bb.utils.contains('DISTRO_FEATURES', 'retroarch-gles', 'egl', '', d)} \
   ${@bb.utils.contains('DISTRO_FEATURES', 'retroarch-gles3', 'egl', '', d)} \
-  ${@bb.utils.filter('DISTRO_FEATURES', 'llvm vulkan x11', d)} \
+  ${@bb.utils.filter('DISTRO_FEATURES', 'vulkan x11', d)} \
   evdev \
-  sdl \
-  libretro \
+  sdl2 \
 "
 
-PACKAGECONFIG[alsa] = "-DENABLE_ALSA=ON,-DENABLE_ALSA=OFF"
-PACKAGECONFIG[analytics] = "-DENABLE_ANALYTICS=ON,-DENABLE_ANALYTICS=OFF"
-PACKAGECONFIG[discord] = "-DUSE_DISCORD_PRESENCE=ON,-DUSE_DISCORD_PRESENCE=OFF"
 PACKAGECONFIG[dsptool] = "-DDSPTOOL=ON,-DDSPTOOL=OFF"
 PACKAGECONFIG[egl] = "-DENABLE_EGL=ON,-DENABLE_EGL=OFF,virtual/egl virtual/libgl virtual/libgles2"
-PACKAGECONFIG[evdev] = "-DENABLE_EVDEV=ON,-DENABLE_EVDEV=OFF"
+PACKAGECONFIG[evdev] = "-DENABLE_EVDEV=ON,-DENABLE_EVDEV=OFF,libevdev"
 PACKAGECONFIG[fastlog] = "-DENCODE_FRAMEDUMPS=ON,-DENCODE_FRAMEDUMPS=OFF"
-PACKAGECONFIG[framedumps] = "-DENCODE_FRAMEDUMPS=ON,-DENCODE_FRAMEDUMPS=OFF"
 PACKAGECONFIG[gdbstub] = "-DGDBSTUB=ON,-DGDBSTUB=OFF"
 PACKAGECONFIG[gprof] = "-DENCODE_FRAMEDUMPS=ON,-DENCODE_FRAMEDUMPS=OFF"
 PACKAGECONFIG[headless] = "-DENABLE_HEADLESS=ON,-DENABLE_HEADLESS=OFF"
-PACKAGECONFIG[libretro] = "-DLIBRETRO=ON -DLIBRETRO_STATIC=1,-DLIBRETRO=OFF"
-PACKAGECONFIG[llvm] = "-DENABLE_LLVM=ON,-DENABLE_LLVM=OFF"
 PACKAGECONFIG[lto] = "-DENABLE_LTO=ON,-DENABLE_LTO=OFF"
 PACKAGECONFIG[oprofile] = "-DOPROFILING=ON,-DOPROFILING=OFF"
-PACKAGECONFIG[pulse] = "-DENABLE_PULSEAUDIO=ON,-DENABLE_PULSEAUDIO=OFF"
-PACKAGECONFIG[qt] = "-DENABLE_QT=ON,-DENABLE_QT=OFF"
-PACKAGECONFIG[sdl] = "-DENABLE_SDL=ON,-DENABLE_SDL=OFF"
+PACKAGECONFIG[sdl2] = "-DENABLE_SDL=ON,-DENABLE_SDL=OFF,libsdl2"
 PACKAGECONFIG[system-enet] = "-DUSE_SHARED_ENET=ON,-DUSE_SHARED_ENET=OFF,,libenet"
-PACKAGECONFIG[upnp] = "-DUSE_UPNP=ON,-DUSE_UPNP=OFF"
 PACKAGECONFIG[vtune] = "-DENABLE_VTUNE=ON,-DENABLE_VTUNE=OFF"
-PACKAGECONFIG[vulkan] = ",,vulkan-loader,vulkan-loader"
+PACKAGECONFIG[vulkan] = ",,vulkan-loader vulkan-headers glslang glslang-native"
 PACKAGECONFIG[x11] = "-DENABLE_X11=ON,-DENABLE_X11=OFF,libxi"
+
+EXTRA_OECMAKE += "-DLIBRETRO=ON"
+


### PR DESCRIPTION
Add a backport patch from dolphin-emu to fix JitArm64
Add some wanted dependencies
Remove some PACKAGECONFIGS that are disabled by default if built with -DLIBRETRO=ON

Signed-off-by: Markus Volk <f_l_k@t-online.de>