### PR TITLE
mame.inc: switch to python3

### DIFF
--- a/recipes-libretro/mame-libretro/mame.inc
+++ b/recipes-libretro/mame-libretro/mame.inc
@@ -1,4 +1,4 @@
-inherit libretro python-dir pythonnative
+inherit libretro python3-dir python3native
 
 # Too much debug symbols are generated
 DEBUG_FLAGS = ""


### PR DESCRIPTION
Python2 is still used here. By switching to python3 we can completely drop
meta-python dependency from meta-retro.

Signed-off-by: Markus Volk <f_l_k@t-online.de>