### PR TITLE
Kirkstone Updates

### DIFF
--- a/conf/distro/include/retro-x86-familly.inc
+++ b/conf/distro/include/retro-x86-familly.inc
@@ -6,6 +6,6 @@ DISTROOVERRIDES:append:x86-64 = ":x86-common"
 
 PREFERRED_PROVIDER:virtual/kernel:x86-common = "${RETROARCH_PREFERRED_KERNEL_FOR_X86}"
 
-MESA_X86_PREFERRED_DRIVERS ?= "gallium gallium-llvm nouveau i915 iris r300 r600 radeonsi"
+MESA_X86_PREFERRED_DRIVERS ?= "gallium gallium-llvm r600"
 
 PACKAGECONFIG:append:pn-mesa:x86-common = " ${MESA_X86_PREFERRED_DRIVERS}"

--- a/dynamic-layers/meta-kodi/recipes-kodi/kodi-game-libretro-pcsx-rearmed/kodi-game-libretro-pcsx-rearmed.bb
+++ b/dynamic-layers/meta-kodi/recipes-kodi/kodi-game-libretro-pcsx-rearmed/kodi-game-libretro-pcsx-rearmed.bb
@@ -2,7 +2,7 @@ SUMMARY = "PCSX ReARMed game client for XBMC"
 HOMEPAGE = "https://github.com/kodi-game/game.libretro.pcsx-rearmed"
 BUGTRACKER = "https://github.com/kodi-game/game.libretro.pcsx-rearmed/issues"
 
-LICENSE = "GPL-2.0"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
 
 inherit kodi-addon

--- a/dynamic-layers/meta-kodi/recipes-kodi/kodi-game-libretro/kodi-game-libretro.bb
+++ b/dynamic-layers/meta-kodi/recipes-kodi/kodi-game-libretro/kodi-game-libretro.bb
@@ -2,7 +2,7 @@ SUMMARY = "Libretro compatibility layer for the Kodi Game API"
 HOMEPAGE = "https://github.com/kodi-game/game.libretro"
 BUGTRACKER = "https://github.com/kodi-game/game.libretro/issues"
 
-LICENSE = "GPL-2.0"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=435d4178fd08b25f9cf911f1c3a0ce1d"
 
 inherit kodi-addon

--- a/recipes-kernel/cpupower/cpupower.bb
+++ b/recipes-kernel/cpupower/cpupower.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Shows and sets processor power related values"
 DESCRIPTION = "cpupower is a collection of tools to examine and tune power \
 saving related features of your processor."
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 DEPENDS = "pciutils gettext-native"
 PROVIDES = "virtual/cpupower"
 

--- a/recipes-libretro-extra/3dengine-libretro/3dengine-libretro_git.bb
+++ b/recipes-libretro-extra/3dengine-libretro/3dengine-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "3D Engine for libretro GL with additional features (camera/location/etc). Should be compatible from libretro 3D/GLES 2.0 and up."
 
-LICENSE = "GPL-3.0"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://license;md5=d32239bcb673463ab874e80d47fae504"
 
 inherit libretro

--- a/recipes-libretro-extra/gme-libretro/gme-libretro_git.bb
+++ b/recipes-libretro-extra/gme-libretro/gme-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Dinothawr - standalone libretro puzzle game"
 
-LICENSE = "GPL-3.0"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 inherit libretro

--- a/recipes-libretro-extra/prboom-libretro/prboom-libretro_git.bb
+++ b/recipes-libretro-extra/prboom-libretro/prboom-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Doom/Doom II engine - PrBoom port for libretro"
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=14aa9744482b9e7ee47eef837e04c26e"
 
 inherit libretro

--- a/recipes-libretro-extra/superflappybirds-libretro/superflappybirds-libretro.bb
+++ b/recipes-libretro-extra/superflappybirds-libretro/superflappybirds-libretro.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Super Flappy Birds - Multiplayer Flappy Bird Clone"
 
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d0a46c0360eccca3e48801dc2333a3c2"
 
 inherit cmake retroarch-paths

--- a/recipes-libretro-extra/tyrquake-libretro/tyrquake-libretro_git.bb
+++ b/recipes-libretro-extra/tyrquake-libretro/tyrquake-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Quake 1 engine - Tyrquake port for libretro"
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=79c2cc4426b9e6f3b9098f02eb47aac1"
 
 inherit libretro

--- a/recipes-libretro/81-libretro/81-libretro_git.bb
+++ b/recipes-libretro/81-libretro/81-libretro_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "ZX81 emulator"
 DESCRIPTION = "Sinclair ZX81 emulator - EightyOne port for libretro"
 
-LICENSE = "GPL-3.0"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=784d7dc7357bd924e8d5642892bf1b6b"
 
 inherit libretro

--- a/recipes-libretro/atari800-libretro/atari800-libretro_git.bb
+++ b/recipes-libretro/atari800-libretro/atari800-libretro_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Atari 8-bit/800/5200 emulator"
 DESCRIPTION = "Atari 8-bit/800/5200 emulator - Atari800 port for libretro"
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://atari800/COPYING;md5=eb723b61539feef013de476e68b5c50a"
 
 inherit libretro

--- a/recipes-libretro/beetle-gba-libretro/beetle-gba-libretro_git.bb
+++ b/recipes-libretro/beetle-gba-libretro/beetle-gba-libretro_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Nintendo Gameboy Advance emulator"
 DESCRIPTION = "Standalone port of Mednafen GBA to libretro"
 
-LICENSE = "GPL-2.0"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6e233eda45c807aa29aeaa6d94bc48a2"
 
 inherit libretro

--- a/recipes-libretro/beetle-lynx-libretro/beetle-lynx-libretro_git.bb
+++ b/recipes-libretro/beetle-lynx-libretro/beetle-lynx-libretro_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Atari Lynx emulator"
 DESCRIPTION = "Mednafen Lynx Port for libretro, itself a fork of Handy"
 
-LICENSE = "GPL-2.0"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6e233eda45c807aa29aeaa6d94bc48a2"
 
 inherit libretro

--- a/recipes-libretro/beetle-ngp-libretro/beetle-ngp-libretro_git.bb
+++ b/recipes-libretro/beetle-ngp-libretro/beetle-ngp-libretro_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Neo Geo Pocket(Color) emulator"
 DESCRIPTION = "Neo Geo Pocket(Color)emu - Mednafen Neo Geo Pocket core port for libretro"
 
-LICENSE = "GPL-2.0"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6e233eda45c807aa29aeaa6d94bc48a2"
 
 inherit libretro

--- a/recipes-libretro/beetle-pce-fast-libretro/beetle-pce-fast-libretro_git.bb
+++ b/recipes-libretro/beetle-pce-fast-libretro/beetle-pce-fast-libretro_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "PC-Engine emulator"
 DESCRIPTION = "PCEngine emu - Mednafen PCE Fast port for libretro"
 
-LICENSE = "GPL-2.0"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6e233eda45c807aa29aeaa6d94bc48a2"
 
 inherit libretro

--- a/recipes-libretro/beetle-pcfx-libretro/beetle-pcfx-libretro_git.bb
+++ b/recipes-libretro/beetle-pcfx-libretro/beetle-pcfx-libretro_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "PCFX emulator"
 DESCRIPTION = "PCFX emulator - Mednafen PCFX Port for libretro"
 
-LICENSE = "GPL-2.0"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6e233eda45c807aa29aeaa6d94bc48a2"
 
 inherit libretro

--- a/recipes-libretro/beetle-psx-libretro/beetle-psx-libretro_git.bb
+++ b/recipes-libretro/beetle-psx-libretro/beetle-psx-libretro_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Sony PlayStation emulator"
 DESCRIPTION = "PSX emulator - Mednafen PSX Port for libretro"
 
-LICENSE = "GPL-2.0"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=801f80980d171dd6425610833a22dbe6"
 
 inherit libretro

--- a/recipes-libretro/beetle-saturn-libretro/beetle-saturn-libretro_git.bb
+++ b/recipes-libretro/beetle-saturn-libretro/beetle-saturn-libretro_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Sega Saturn emulator"
 DESCRIPTION = "Sega Saturn emulator - Mednafen Saturn port for libretro"
 
-LICENSE = "GPL-2.0"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6e233eda45c807aa29aeaa6d94bc48a2"
 
 inherit libretro

--- a/recipes-libretro/beetle-supergrafx-libretro/beetle-supergrafx-libretro_git.bb
+++ b/recipes-libretro/beetle-supergrafx-libretro/beetle-supergrafx-libretro_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "SuperGrafx TG-16 emulator"
 DESCRIPTION = "SuperGrafx TG-16 emulator - Mednafen PCE Fast port for libretro"
 
-LICENSE = "GPL-2.0"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6e233eda45c807aa29aeaa6d94bc48a2"
 
 inherit libretro

--- a/recipes-libretro/beetle-vb-libretro/beetle-vb-libretro_git.bb
+++ b/recipes-libretro/beetle-vb-libretro/beetle-vb-libretro_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Nintendo Virtual Boy emulator"
 DESCRIPTION = "Virtual Boy emulator - Mednafen VB (optimised) port for libretro"
 
-LICENSE = "GPL-2.0"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6e233eda45c807aa29aeaa6d94bc48a2"
 
 inherit libretro

--- a/recipes-libretro/beetle-wswan-libretro/beetle-wswan-libretro_git.bb
+++ b/recipes-libretro/beetle-wswan-libretro/beetle-wswan-libretro_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Wonderswan emulator"
 DESCRIPTION = "Wonderswan emulator - Mednafen WonderSwan core port for libretro"
 
-LICENSE = "GPL-2.0"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6e233eda45c807aa29aeaa6d94bc48a2"
 
 inherit libretro

--- a/recipes-libretro/bluemsx-libretro/bluemsx-libretro_git.bb
+++ b/recipes-libretro/bluemsx-libretro/bluemsx-libretro_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "MSX/MSX2/Colecovision emulator"
 DESCRIPTION = "MSX/MSX2/Colecovision emu - blueMSX port for libretro"
 
-LICENSE = "GPL-2.0"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://license.txt;md5=7e47935857eb320b159bf6ec4114c655"
 
 inherit libretro

--- a/recipes-libretro/bsnes-libretro/bsnes-libretro_git.bb
+++ b/recipes-libretro/bsnes-libretro/bsnes-libretro_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Super Nintendo emulator"
 DESCRIPTION = "Super Nintendo emulator - bsnes port for libretro"
 
-LICENSE = "GPL-3.0 & ISC"
+LICENSE = "GPL-3.0-only & ISC"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=fe114267df72c30b064ae55ca5242069"
 
 inherit libretro

--- a/recipes-libretro/caprice32-libretro/caprice32-libretro_git.bb
+++ b/recipes-libretro/caprice32-libretro/caprice32-libretro_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Amstrad CPC emulator"
 DESCRIPTION = "Amstrad CPC emu - Caprice32 port for libretro"
 
-LICENSE = "GPL-2.0"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://cap32/COPYING.txt;md5=8ca43cbc842c2336e835926c2166c28b"
 
 inherit libretro

--- a/recipes-libretro/desmume-libretro/desmume-libretro_git.bb
+++ b/recipes-libretro/desmume-libretro/desmume-libretro_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Nintendo DS emulator"
 DESCRIPTION = "Nintendo DS emulator - DESMUME"
 
-LICENSE = "GPL-2.0"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://desmume/COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 inherit libretro

--- a/recipes-libretro/desmume-libretro/desmume2015-libretro_git.bb
+++ b/recipes-libretro/desmume-libretro/desmume2015-libretro_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Nintendo DS emulator"
 DESCRIPTION = "Nintendo DS emulator - DESMUME"
 
-LICENSE = "GPL-2.0"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://desmume/COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 inherit libretro

--- a/recipes-libretro/dolphin-libretro/dolphin-libretro_git.bb
+++ b/recipes-libretro/dolphin-libretro/dolphin-libretro_git.bb
@@ -2,7 +2,7 @@ SUMMARY = "Nintendo GameCube / Wii emulator"
 DESCRIPTION = "Dolphin is a GameCube / Wii emulator, allowing you to play \
 games for these two platforms on PC with improvements."
 
-LICENSE = "GPL-2.0"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://license.txt;md5=751419260aa954499f7abaabaa882bbe"
 
 inherit libretro-cmake

--- a/recipes-libretro/dosbox-libretro/dosbox-libretro_git.bb
+++ b/recipes-libretro/dosbox-libretro/dosbox-libretro_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "MS-DOS emulator"
 DESCRIPTION = "Dosbox port to libretro"
 
-LICENSE = "GPL-2.0"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=94d55d512a9ba36caa9b7df079bae19f"
 
 inherit libretro

--- a/recipes-libretro/dosbox-pure-libretro/dosbox-pure-libretro_git.bb
+++ b/recipes-libretro/dosbox-pure-libretro/dosbox-pure-libretro_git.bb
@@ -2,7 +2,7 @@ SUMMARY = "MS-DOS emulator"
 DESCRIPTION = "DOSBox Pure is a new fork of DOSBox built for RetroArch/Libretro \ 
 aiming for simplicity and ease of use."
 
-LICENSE = "GPL-2.0"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=7c050190136f70e95bb9873bf63cf427"
 
 inherit libretro

--- a/recipes-libretro/fceumm-libretro/fceumm-libretro_git.bb
+++ b/recipes-libretro/fceumm-libretro/fceumm-libretro_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Nintendo Entertainment System emulator"
 DESCRIPTION = "Nintendo Entertainment System emulator - FCEUmm libretro port"
 
-LICENSE = "GPL-2.0"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://Copying;md5=6e233eda45c807aa29aeaa6d94bc48a2"
 
 inherit libretro

--- a/recipes-libretro/freechaf-libretro/freechaf-libretro_git.bb
+++ b/recipes-libretro/freechaf-libretro/freechaf-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "ChannelF emulator for libretro"
 
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=2f5b803c8170f71ee6bf8ed95ce49be9"
 
 inherit libretro

--- a/recipes-libretro/freeintv-libretro/freeintv-libretro_git.bb
+++ b/recipes-libretro/freeintv-libretro/freeintv-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Intellivision emulator for libretro"
 
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=a8ef2e7868580064326544319a8cb408"
 
 inherit libretro

--- a/recipes-libretro/frodo-libretro/frodo-libretro_git.bb
+++ b/recipes-libretro/frodo-libretro/frodo-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Frodo - Commodore 64 emulator"
 
-LICENSE = "GPL-3.0"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=0636e73ff0215e8d672dc4c32c317bb3"
 
 inherit libretro

--- a/recipes-libretro/fuse-libretro/fuse-libretro_git.bb
+++ b/recipes-libretro/fuse-libretro/fuse-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "ZX Spectrum emu - Fuse port for libretro"
 
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=784d7dc7357bd924e8d5642892bf1b6b"
 
 inherit libretro

--- a/recipes-libretro/gambatte-libretro/gambatte-libretro_git.bb
+++ b/recipes-libretro/gambatte-libretro/gambatte-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Gameboy Color emu - libgambatte port for libretro"
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
 
 inherit libretro

--- a/recipes-libretro/gearsystem-libretro/gearsystem-libretro_git.bb
+++ b/recipes-libretro/gearsystem-libretro/gearsystem-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Sega 8 bit emu - Gearsystem port for libretro"
 
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d32239bcb673463ab874e80d47fae504"
 
 inherit libretro

--- a/recipes-libretro/gpsp-libretro/gpsp-libretro_git.bb
+++ b/recipes-libretro/gpsp-libretro/gpsp-libretro_git.bb
@@ -1,4 +1,4 @@
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
 
 inherit libretro

--- a/recipes-libretro/hatari-libretro/hatari-libretro_git.bb
+++ b/recipes-libretro/hatari-libretro/hatari-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Atari emulator - Hatari port for libretro"
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://gpl.txt;md5=751419260aa954499f7abaabaa882bbe"
 
 inherit libretro

--- a/recipes-libretro/kronos-libretro/kronos-libretro_git.bb
+++ b/recipes-libretro/kronos-libretro/kronos-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Saturn & ST-V emulator - Kronos port for libretro"
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://yabause/COPYING;md5=4b446a5a0b773c458f6a5b3288522b62"
 
 inherit libretro

--- a/recipes-libretro/mame-libretro/mame2016-libretro_git.bb
+++ b/recipes-libretro/mame-libretro/mame2016-libretro_git.bb
@@ -1,4 +1,4 @@
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=89436197a991695e278e47475b4ff7ae"
 
 require mame.inc

--- a/recipes-libretro/masen-libretro/masen-libretro_git.bb
+++ b/recipes-libretro/masen-libretro/masen-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "High-accuracy NES and Famicom emulator"
 
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d32239bcb673463ab874e80d47fae504"
 
 inherit libretro

--- a/recipes-libretro/masen-s-libretro/masen-s-libretro_git.bb
+++ b/recipes-libretro/masen-s-libretro/masen-s-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Mesen-S is a cross-platform SNES emulator for Windows & Linux built in C++."
 
-LICENSE = "GPL-3.0"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d32239bcb673463ab874e80d47fae504"
 
 inherit libretro

--- a/recipes-libretro/melonds-libretro/melonds-libretro_git.bb
+++ b/recipes-libretro/melonds-libretro/melonds-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "MelonDS - Nintendo DS emulator"
 
-LICENSE = "GPL-3.0"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d32239bcb673463ab874e80d47fae504"
 
 inherit libretro

--- a/recipes-libretro/neocd-libretro/neocd-libretro_git.bb
+++ b/recipes-libretro/neocd-libretro/neocd-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Neo Geo CD emulator for libretro"
 
-LICENSE = "LGPL-3.0"
+LICENSE = "LGPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=f839e273ca0906304c90b406662bf17a"
 
 inherit libretro

--- a/recipes-libretro/nestopia-libretro/nestopia-libretro_git.bb
+++ b/recipes-libretro/nestopia-libretro/nestopia-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NES emu - Nestopia (enhanced) port for libretro"
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=686e6cb566fd6382c9fcc7a557bf4544"
 
 inherit libretro

--- a/recipes-libretro/nxengine-libretro/nxengine-libretro_git.bb
+++ b/recipes-libretro/nxengine-libretro/nxengine-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Cave Story engine clone - NxEngine port for libretro"
 
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://nxengine/LICENSE;md5=d32239bcb673463ab874e80d47fae504"
 
 inherit libretro

--- a/recipes-libretro/parallel-n64-libretro/parallel-n64-libretro_git.bb
+++ b/recipes-libretro/parallel-n64-libretro/parallel-n64-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "N64 emu - Highly modified Mupen64Plus port for libretro"
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://mupen64plus-core/LICENSES;md5=6bf42b6befd3315498f337409d7f83c2"
 
 inherit libretro

--- a/recipes-libretro/pcsx2-libretro/pcsx2-libretro_git.bb
+++ b/recipes-libretro/pcsx2-libretro/pcsx2-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "PCSX2 - The Playstation 2 Emulator."
 
-LICENSE = "GPL-3.0"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://COPYING.GPLv3;md5=d32239bcb673463ab874e80d47fae504"
 
 inherit libretro-cmake python3native

--- a/recipes-libretro/pokemini-libretro/pokemini-libretro_git.bb
+++ b/recipes-libretro/pokemini-libretro/pokemini-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Pokemon Mini emulator - PokeMini port for libretro"
 
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=65d7e3de6ed0d7bb08187100789e7221"
 
 inherit libretro

--- a/recipes-libretro/ppsspp-libretro/ppsspp-libretro_git.bb
+++ b/recipes-libretro/ppsspp-libretro/ppsspp-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "PlayStation Portable emu - PPSSPP port for libretro"
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE.TXT;md5=e336f8162cddec7981e240f46825d8a2"
 
 inherit libretro-cmake

--- a/recipes-libretro/prosystem-libretro/prosystem-libretro_git.bb
+++ b/recipes-libretro/prosystem-libretro/prosystem-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Atari 7800 ProSystem emu - ProSystem port for libretro"
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://License.txt;md5=ec2ee434a4ad8ef5c1eae190fff988a9"
 
 inherit libretro

--- a/recipes-libretro/px68k-libretro/px68k-libretro_git.bb
+++ b/recipes-libretro/px68k-libretro/px68k-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "SHARP X68000 Emulator"
 
-LICENSE = "GPL-3.0"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://README.MD;md5=effab21f24c6d2805b27a80942340363"
 
 inherit libretro

--- a/recipes-libretro/quicknes-libretro/quicknes-libretro_git.bb
+++ b/recipes-libretro/quicknes-libretro/quicknes-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NES emulator - QuickNES Port for libretro"
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 inherit libretro

--- a/recipes-libretro/race-libretro/race-libretro_git.bb
+++ b/recipes-libretro/race-libretro/race-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "RACE NGPC emulator"
 
-LICENSE = "GPL-2.0"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://license.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 inherit libretro

--- a/recipes-libretro/retro8-libretro/retro8-libretro_git.bb
+++ b/recipes-libretro/retro8-libretro/retro8-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "PICO-8 implementation with SDL2 and RetroArch back-ends"
 
-LICENSE = "GPL-3.0"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1ebbd3e34237af26da5dc08a4e440464"
 
 inherit libretro

--- a/recipes-libretro/smsplus-gx-libretro/smsplus-gx-libretro_git.bb
+++ b/recipes-libretro/smsplus-gx-libretro/smsplus-gx-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Sega Master System & Game Gear emu - SMSPlus (enhanced) port for libretro"
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://docs/license;md5=0636e73ff0215e8d672dc4c32c317bb3"
 
 inherit libretro

--- a/recipes-libretro/stella2014-libretro/stella2014-libretro_git.bb
+++ b/recipes-libretro/stella2014-libretro/stella2014-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Atari 2600 emulator - Stella port for libretro"
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://stella/license.txt;md5=435d4178fd08b25f9cf911f1c3a0ce1d"
 
 inherit libretro

--- a/recipes-libretro/swanstation-libretro/swanstation-libretro_git.bb
+++ b/recipes-libretro/swanstation-libretro/swanstation-libretro_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Sony PlayStation emulator"
 DESCRIPTION = "Fast-ish PlayStation 1 emulator for PC and Android"
 
-LICENSE = "GPL-3.0"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d32239bcb673463ab874e80d47fae504"
 
 inherit libretro-cmake

--- a/recipes-libretro/tgbdual-libretro/tgbdual-libretro_git.bb
+++ b/recipes-libretro/tgbdual-libretro/tgbdual-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Gameboy Color emu - TGB Dual port for libretro"
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://docs/COPYING-2.0.txt;md5=cbbd794e2a0a289b9dfcc9f513d1996e"
 
 inherit libretro

--- a/recipes-libretro/theodore-libretro/theodore-libretro_git.bb
+++ b/recipes-libretro/theodore-libretro/theodore-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Thomson MO/TO system emulator"
 
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d32239bcb673463ab874e80d47fae504"
 
 inherit libretro

--- a/recipes-libretro/vba-next-libretro/vba-next-libretro_git.bb
+++ b/recipes-libretro/vba-next-libretro/vba-next-libretro_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Optimized port of VBA-M to Libretro."
 
-LICENSE = "GPL-2.0"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=63ecf6d881e3ca7dab50e686948a6286"
 
 inherit libretro

--- a/recipes-libretro/vbam-libretro/vbam-libretro_git.bb
+++ b/recipes-libretro/vbam-libretro/vbam-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Visual Boy Advance - A fork of VBA-M with libretro integration"
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://doc/License.txt;md5=ad8ac3e11cc39f83fcaa6cd492075985"
 
 inherit libretro

--- a/recipes-libretro/vecx-libretro/vecx-libretro_git.bb
+++ b/recipes-libretro/vecx-libretro/vecx-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Vectrex emulator - vecx port for libretro"
 
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=86be7c1121127c4ab250ab6043117e46"
 
 inherit libretro

--- a/recipes-libretro/vemulator-libretro/vemulator-libretro_git.bb
+++ b/recipes-libretro/vemulator-libretro/vemulator-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "A port of the SEGA Visual Memory Unit emulator VeMUlator for libretro."
 
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=1ebbd3e34237af26da5dc08a4e440464"
 
 inherit libretro

--- a/recipes-libretro/vice-libretro/vice-libretro.inc
+++ b/recipes-libretro/vice-libretro/vice-libretro.inc
@@ -1,6 +1,6 @@
 DESCRIPTION = "C64 emulator - port of VICE for libretro"
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://vice/COPYING;md5=c93c0550bd3173f4504b2cbd8991e50b"
 
 inherit libretro

--- a/recipes-libretro/virtualjaguar-libretro/virtualjaguar-libretro_git.bb
+++ b/recipes-libretro/virtualjaguar-libretro/virtualjaguar-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Atari Jaguar emu - Virtual Jaguar (optimised) port for libretro"
 
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://docs/GPLv3;md5=d32239bcb673463ab874e80d47fae504"
 
 inherit libretro

--- a/recipes-libretro/yabause-libretro/yabause-libretro_git.bb
+++ b/recipes-libretro/yabause-libretro/yabause-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Sega Saturn emu - Yabause (optimised) port for libretro"
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://yabause/COPYING;md5=4b446a5a0b773c458f6a5b3288522b62"
 
 inherit libretro

--- a/recipes-qt/cool-retro-term/cool-retro-term_1.1.1.bb
+++ b/recipes-qt/cool-retro-term/cool-retro-term_1.1.1.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Terminal emulator which mimics the look and feel of the old cathode tube screens"
 HOMEPAGE = "https://github.com/Swordfish90/cool-retro-term"
 
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://gpl-3.0.txt;md5=d32239bcb673463ab874e80d47fae504"
 
 inherit qmake5

--- a/recipes-qt/retro-menu/retro-menu_git.bb
+++ b/recipes-qt/retro-menu/retro-menu_git.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Retro menu launcher for retro distribution. Written in Qt / QML."
 HOMEPAGE = "https://github.com/dev-0x7C6/retro-menu.git"
 
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1ebbd3e34237af26da5dc08a4e440464"
 
 inherit cmake_qt5 libretro-version retroarch-paths

--- a/recipes-retroarch/retroarch/retroarch.inc
+++ b/recipes-retroarch/retroarch/retroarch.inc
@@ -8,7 +8,7 @@ We refer to these as <libretro cores>."
 HOMEPAGE = "https://www.retroarch.com/"
 BUGTRACKER = "https://github.com/libretro/RetroArch/issues"
 
-LICENSE = "GPL-3.0"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 
 SRC_URI = "gitsm://github.com/libretro/RetroArch.git;protocol=https;branch=master ${RETROARCH_PATCHES}"

--- a/recipes-support/rtkit/rtkit_0.13.bb
+++ b/recipes-support/rtkit/rtkit_0.13.bb
@@ -8,7 +8,7 @@ be used by normal user processes."
 HOMEPAGE = "https://github.com/heftig/rtkit"
 BUGTRACKER = "https://github.com/heftig/rtkit/issues"
 
-LICENSE = "GPL-3.0 & BSD-3-Clause"
+LICENSE = "GPL-3.0-only & BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=a8e768468b658b3ed44971b53d4a6716"
 
 SRC_URI += "git://github.com/heftig/rtkit.git;protocol=https;branch=master"


### PR DESCRIPTION
Update LICENSE variable to use SPDX license identifiers

Remove some unbuildable drivers after mesa 22.0.0. update where dri1 has been removed