### PR TITLE
pcsx-rearmed-libretro: fix build for aarch64

### DIFF
--- a/recipes-libretro/pcsx-rearmed-libretro/pcsx-rearmed-libretro_git.bb
+++ b/recipes-libretro/pcsx-rearmed-libretro/pcsx-rearmed-libretro_git.bb
@@ -9,13 +9,14 @@ inherit libretro
 LIBRETRO_GIT_REPO = "github.com/libretro/pcsx_rearmed.git"
 
 PREFFERED_DYNAMIC_RECOMPILER ?= "lightrec"
-PREFFERED_DYNAMIC_RECOMPILER:arm32 = "ari64"
+PREFFERED_DYNAMIC_RECOMPILER:armarch = "ari64"
 
 PREFFERED_BUILTIN_GPU ?= "${@bb.utils.contains('TUNE_FEATURES', 'neon', 'neon', 'peops', d)}"
 PREFFERED_BUILTIN_GPU:arm64 = "unai"
 
-PCSX_THREAD_RENDERING ?= "0"
-PCSX_THREAD_RENDERING:arm64 = "1"
+PCSX_THREAD_RENDERING ?= "1"
+PCSX_THREAD_RENDERING:arm = "0"
+
 
 LIBRETRO_COMMON_FLAGS = "-fPIC -shared"
 

--- a/recipes-libretro/quasi88-libretro/quasi88-libretro_git.bb
+++ b/recipes-libretro/quasi88-libretro/quasi88-libretro_git.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NEC PC-8801 emu - Quasi88 port for libretro"
 
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=9e54495b2bbbde6f54c556fb76c1698f"
 
 inherit libretro


### PR DESCRIPTION
- use ari64 DYNAMIC_RECOMPILER for both arm and aarch64
- enable THREAD_RENDERER for all but arm