### PR TITLE
retro-wayland.conf: drop busybox dependency

### DIFF
--- a/conf/distro/retro-wayland.conf
+++ b/conf/distro/retro-wayland.conf
@@ -34,3 +34,13 @@ PREPARE_DISTRO_FEATURES = " \
 "
 
 DISTRO_FEATURES = "${@' '.join(sorted('${PREPARE_DISTRO_FEATURES}'.split()))}"
+
+# Replace busybox
+PREFERRED_PROVIDER_virtual/base-utils = "coreutils"
+VIRTUAL-RUNTIME_base-utils = "coreutils"
+VIRTUAL-RUNTIME_base-utils-hwclock = "util-linux-hwclock"
+VIRTUAL-RUNTIME_base-utils-syslog = ""
+
+# Use systemd for system initialization
+VIRTUAL-RUNTIME_login_manager = "systemd"
+VIRTUAL-RUNTIME_dev_manager = "systemd"


### PR DESCRIPTION
Signed-off-by: Markus Volk <f_l_k@t-online.de>

This commit would remove the remaining dependencies on busybox and use coreutils instead for wayland images