### PR TITLE
pulseaudio.bbappend: allow to use pipewire-pulse

### DIFF
--- a/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
+++ b/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
@@ -1,17 +1,22 @@
 inherit retro-user
 
-FILES:${PN}-server += "${RETRO_USER_DEFAULT_TARGET_WANTS} ${RETRO_USER_SOCKETS_TARGET_WANTS}"
+PACKAGES += "pulseaudio-user-service"
+FILES:${PN}-user-service = "${RETRO_USER_DEFAULT_TARGET_WANTS} ${RETRO_USER_SOCKETS_TARGET_WANTS}"
 
 do_install:append() {
     if ${@bb.utils.contains('DISTRO_FEATURES', 'pulseaudio', 'true', 'false', d)}; then
         install -d ${D}${RETRO_USER_DEFAULT_TARGET_WANTS}
         install -d ${D}${RETRO_USER_SOCKETS_TARGET_WANTS}
-
-        ln -fs ${systemd_user_unitdir}/pulseaudio.service ${D}${RETRO_USER_DEFAULT_TARGET_WANTS}/pulseaudio.service
-        ln -fs ${systemd_user_unitdir}/pulseaudio.socket ${D}${RETRO_USER_SOCKETS_TARGET_WANTS}/pulseaudio.socket
-
+        if ${@bb.utils.contains('DISTRO_FEATURES', 'pipewire', 'true', 'false', d)}; then
+            ln -fs ${systemd_user_unitdir}/pipewire-pulse.service ${D}${RETRO_USER_DEFAULT_TARGET_WANTS}/pipewire-pulse.service
+            ln -fs ${systemd_user_unitdir}/pipewire-pulse.socket ${D}${RETRO_USER_SOCKETS_TARGET_WANTS}/pipewire-pulse.socket
+            ln -fs ${systemd_user_unitdir}/pipewire.service ${D}${RETRO_USER_DEFAULT_TARGET_WANTS}/pipewire.service
+            ln -fs ${systemd_user_unitdir}/pipewire.socket ${D}${RETRO_USER_SOCKETS_TARGET_WANTS}/pipewire.socket
+            ln -fs ${systemd_user_unitdir}/pipewire-media-session.service ${D}${RETRO_USER_DEFAULT_TARGET_WANTS}/pipewire-media-session.service
+        else
+            ln -fs ${systemd_user_unitdir}/pulseaudio.service ${D}${RETRO_USER_DEFAULT_TARGET_WANTS}/pulseaudio.service
+            ln -fs ${systemd_user_unitdir}/pulseaudio.socket ${D}${RETRO_USER_SOCKETS_TARGET_WANTS}/pulseaudio.socket
+        fi
         chown ${RETRO_USER_NAME}:${RETRO_USER_NAME} -R ${D}${RETRO_USER_HOMEDIR}/
     fi
 }
-
-INSANE_SKIP:${PN}-server += "host-user-contaminated"


### PR DESCRIPTION
pipewire-pulse is a drop-in replacement for the pulseaudio-server. Only one
of them should be running at a time.

This commit would enable pipewire-pulse if pulseaudio and pipewire are present
in DISTRO_FEATURES.

The systemd-user-services are packaged into a separate package to make them
installable without the pulseaudio-server

Signed-off-by: Markus Volk <f_l_k@t-online.de>