### PR TITLE
dolphin: dont use logging bbclass

### DIFF
--- a/files/dolphin-32bit-configuration.inc
+++ b/files/dolphin-32bit-configuration.inc
@@ -2,7 +2,7 @@
 # it's possible to compile 32bit version with "generic" PACKAGECONFIG
 # but it's resulting in very poor runtime performance
 
-inherit logging retro-overrides
+inherit retro-overrides
 
 PACKAGECONFIG:append:32bit = " generic"
 

--- a/recipes-emulation/dolphin-emu/dolphin-emu_git.bb
+++ b/recipes-emulation/dolphin-emu/dolphin-emu_git.bb
@@ -7,7 +7,7 @@ SRC_URI = "gitsm://github.com/dolphin-emu/dolphin.git;protocol=https;branch=mast
 SRCREV = "954f27c5d7289b2b806d0fb94dd105edaa1bb4be"
 S = "${WORKDIR}/git"
 
-inherit cmake_qt5 retro-overrides gettext logging libretro-version
+inherit cmake_qt5 retro-overrides gettext libretro-version
 require files/dolphin-32bit-configuration.inc
 
 OECMAKE_FIND_ROOT_PATH_MODE_PROGRAM = "BOTH"


### PR DESCRIPTION
Current poky master has split classes into classes-global and classes-recipes

It looks like the global ones (like logging) are not accessible from within recipes:

ERROR: ParseError at /home/f_l_k/poky/meta-retro/files/dolphin-32bit-configuration.inc:5: Could not inherit file classes/logging.bbclass                         | ETA:  --:--:--
ERROR: Parsing halted due to errors, see error messages above

ERROR: ParseError at /home/f_l_k/poky/meta-retro/recipes-emulation/dolphin-emu/dolphin-emu_git.bb:10: Could not inherit file classes/logging.bbclass              | ETA:  0:00:01
ERROR: Parsing halted due to errors, see error messages above

Signed-off-by: Markus Volk <f_l_k@t-online.de>