### PR TITLE
retro-user.bbclass: improve password encryption; add dbus configuration

### DIFF
--- a/classes/retro-user.bbclass
+++ b/classes/retro-user.bbclass
@@ -1,19 +1,18 @@
 inherit useradd extrausers
 
 RETRO_USER_ID ?= "1000"
-RETRO_USER_GROUPS ?= "audio dialout disk input plugdev root shutdown sudo tty users video"
-RETRO_USER_NAME ?= "retro"
+RETRO_USER_GROUPS ?= "audio dialout disk i2c input netdev plugdev shutdown sudo tty users video"
+RETRO_USER_NAME ??= "retro"
+RETRO_USER_PASSWORD ??= "retro"
+RETRO_USER_PASSWORD_ENCRYPTED ??= "$(openssl passwd -5 ${RETRO_USER_PASSWORD})"
 
-# Password is set to 'retro'
-# to generate:
-# printf "%q" $(mkpasswd -m sha256crypt retro)
-
-RETRO_USER_PASSWORD ?= "\$5\$SxKdDqV.7pNL\$Hyj/YHs5efWsFgxxn120QFVdzdSM/WMkUf1ot3IHmT0"
+ROOT_PASSWORD ??= "root"
+ROOT_PASSWORD_ENCRYPTED ??= "$(openssl passwd -5 ${ROOT_PASSWORD})"
 
 RETRO_USER_HOMEDIR ?= "/home/${RETRO_USER_NAME}"
 
-RETRO_USER_DEFAULT_TARGET_WANTS ?= "${RETRO_USER_HOMEDIR}/.config/systemd/user/default.target.wants" 
-RETRO_USER_SOCKETS_TARGET_WANTS ?= "${RETRO_USER_HOMEDIR}/.config/systemd/user/sockets.target.wants" 
+RETRO_USER_DEFAULT_TARGET_WANTS ?= "${RETRO_USER_HOMEDIR}/.config/systemd/user/default.target.wants"
+RETRO_USER_SOCKETS_TARGET_WANTS ?= "${RETRO_USER_HOMEDIR}/.config/systemd/user/sockets.target.wants"
 
 RDEPENDS:${PN}:prepend = "bash "
 
@@ -24,7 +23,7 @@ RETRO_USERADD_SET_UID ?= "--uid ${RETRO_USER_ID}"
 RETRO_USERADD_SET_HOMEDIR ?= "--home ${RETRO_USER_HOMEDIR}"
 RETRO_USERADD_SET_SHELL ?= "--shell /bin/bash"
 
-EXTRA_USERS_PARAMS += "usermod -p '${RETRO_USER_PASSWORD}' ${RETRO_USER_NAME};"
+GROUPADD_PARAM:${PN} = "i2c; netdev"
 
 RETRO_USERADD_COMMAND ?= " \
   ${RETRO_USERADD_CREATE_HOME} \
@@ -38,3 +37,6 @@ RETRO_USERADD_COMMAND ?= " \
 
 USERADD_PACKAGES = "${PN}"
 USERADD_PARAM:${PN} = "${@' '.join('${RETRO_USERADD_COMMAND}'.split())}"
+
+EXTRA_USERS_PARAMS += "usermod -p '${ROOT_PASSWORD_ENCRYPTED}' root;"
+EXTRA_USERS_PARAMS += "usermod -p '${RETRO_USER_PASSWORD_ENCRYPTED}' ${RETRO_USER_NAME};"


### PR DESCRIPTION
- Add the user to netdev group. This is needed for iwd dbus communication
- Add the user to i2c group to allow dbus communication with i2c bus, so we can set brightness/color for external displays
- Allow to set RETRO_USER_PASSWORD globally in either cleartext or encrypted
- Since the root account is created automatically, also set a password for it

Signed-off-by: Markus Volk <f_l_k@t-online.de>